### PR TITLE
[FEAT]: initialize core authorization interfaces and service structure

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/lsflk/bouncer
+
+go 1.25.0

--- a/internal/authorization/service.go
+++ b/internal/authorization/service.go
@@ -1,0 +1,35 @@
+package authorization
+
+import "context"
+
+// Expected store interface internally (matches pkg/bouncer.Store)
+type Store interface {
+	HasPermission(ctx context.Context, subjectID string, resourceID string, permission string) (bool, error)
+	GrantPermission(ctx context.Context, subjectID string, resourceID string, permission string) error
+	RevokePermission(ctx context.Context, subjectID string, resourceID string, permission string) error
+}
+
+// Service provides authorization capabilities by interacting with the storage layer.
+type Service struct {
+	store Store
+}
+
+// NewService creates a new Service instance backed by the provided store.
+func NewService(store Store) *Service {
+	return &Service{store: store}
+}
+
+// HasPermission checks if the subject has the requested permission on the resource.
+func (s *Service) HasPermission(ctx context.Context, subjectID string, resourceID string, permission string) (bool, error) {
+	return s.store.HasPermission(ctx, subjectID, resourceID, permission)
+}
+
+// GrantPermission grants the requested permission on the resource to the subject.
+func (s *Service) GrantPermission(ctx context.Context, subjectID string, resourceID string, permission string) error {
+	return s.store.GrantPermission(ctx, subjectID, resourceID, permission)
+}
+
+// RevokePermission revokes the requested permission on the resource from the subject.
+func (s *Service) RevokePermission(ctx context.Context, subjectID string, resourceID string, permission string) error {
+	return s.store.RevokePermission(ctx, subjectID, resourceID, permission)
+}

--- a/pkg/bouncer/authorizer.go
+++ b/pkg/bouncer/authorizer.go
@@ -1,0 +1,17 @@
+package bouncer
+
+import "context"
+
+// Authorizer represents the main entrypoint for checking and managing permissions.
+type Authorizer interface {
+	HasPermission(ctx context.Context, subjectID string, resourceID string, permission string) (bool, error)
+	GrantPermission(ctx context.Context, subjectID string, resourceID string, permission string) error
+	RevokePermission(ctx context.Context, subjectID string, resourceID string, permission string) error
+}
+
+// Store represents the persistence layer required by the Authorizer.
+type Store interface {
+	HasPermission(ctx context.Context, subjectID string, resourceID string, permission string) (bool, error)
+	GrantPermission(ctx context.Context, subjectID string, resourceID string, permission string) error
+	RevokePermission(ctx context.Context, subjectID string, resourceID string, permission string) error
+}

--- a/pkg/bouncer/service.go
+++ b/pkg/bouncer/service.go
@@ -1,0 +1,10 @@
+package bouncer
+
+import (
+	"github.com/lsflk/bouncer/internal/authorization"
+)
+
+// New creates a new Bouncer Authorizer instance powered by the provided store.
+func New(store Store) Authorizer {
+	return authorization.NewService(store)
+}


### PR DESCRIPTION
## Overview
This PR establishes the foundational architecture and public package structure for the Bouncer library. It defines the core interfaces acting as the API boundary and sets up the internal authorization service to handle subsequent domain logic.

## Changes Included
- **`pkg/bouncer/authorizer.go`**: Added the public `Authorizer` and `Store` interfaces indicating the core methods (`HasPermission`, `GrantPermission`, `RevokePermission`).
- **`pkg/bouncer/service.go`**: Implemented the public `New(store Store)` constructor ensuring consumers have a distinct entry point.
- **`internal/authorization/service.go`**: Established our decoupled internal authorization logic. 
  - *Note:* We utilized the Consumer-Defined Interface pattern here to strictly require a `Store`, ensuring we stay decoupled from `pkg/bouncer` and avoid import loops within Go.