### PR TITLE
[FEAT]: Implement internal subject, resource, and permission domain types

### DIFF
--- a/internal/authorization/service.go
+++ b/internal/authorization/service.go
@@ -1,6 +1,12 @@
 package authorization
 
-import "context"
+import (
+	"context"
+
+	"github.com/lsflk/bouncer/internal/permission"
+	"github.com/lsflk/bouncer/internal/resource"
+	"github.com/lsflk/bouncer/internal/subject"
+)
 
 // Expected store interface internally (matches pkg/bouncer.Store)
 type Store interface {
@@ -20,16 +26,28 @@ func NewService(store Store) *Service {
 }
 
 // HasPermission checks if the subject has the requested permission on the resource.
-func (s *Service) HasPermission(ctx context.Context, subjectID string, resourceID string, permission string) (bool, error) {
-	return s.store.HasPermission(ctx, subjectID, resourceID, permission)
+func (s *Service) HasPermission(ctx context.Context, subjectStr string, resourceStr string, permissionStr string) (bool, error) {
+	subID := subject.ID(subjectStr)
+	resID := resource.ID(resourceStr)
+	permName := permission.Name(permissionStr)
+
+	return s.store.HasPermission(ctx, string(subID), string(resID), string(permName))
 }
 
 // GrantPermission grants the requested permission on the resource to the subject.
-func (s *Service) GrantPermission(ctx context.Context, subjectID string, resourceID string, permission string) error {
-	return s.store.GrantPermission(ctx, subjectID, resourceID, permission)
+func (s *Service) GrantPermission(ctx context.Context, subjectStr string, resourceStr string, permissionStr string) error {
+	subID := subject.ID(subjectStr)
+	resID := resource.ID(resourceStr)
+	permName := permission.Name(permissionStr)
+
+	return s.store.GrantPermission(ctx, string(subID), string(resID), string(permName))
 }
 
 // RevokePermission revokes the requested permission on the resource from the subject.
-func (s *Service) RevokePermission(ctx context.Context, subjectID string, resourceID string, permission string) error {
-	return s.store.RevokePermission(ctx, subjectID, resourceID, permission)
+func (s *Service) RevokePermission(ctx context.Context, subjectStr string, resourceStr string, permissionStr string) error {
+	subID := subject.ID(subjectStr)
+	resID := resource.ID(resourceStr)
+	permName := permission.Name(permissionStr)
+
+	return s.store.RevokePermission(ctx, string(subID), string(resID), string(permName))
 }

--- a/internal/permission/permission.go
+++ b/internal/permission/permission.go
@@ -1,0 +1,4 @@
+package permission
+
+// Name represents a specific capability or action.
+type Name string

--- a/internal/resource/resource.go
+++ b/internal/resource/resource.go
@@ -1,0 +1,4 @@
+package resource
+
+// ID represents an opaque identifier for an object being accessed.
+type ID string

--- a/internal/subject/subject.go
+++ b/internal/subject/subject.go
@@ -1,0 +1,4 @@
+package subject
+
+// ID represents an opaque identifier for an actor requesting access.
+type ID string


### PR DESCRIPTION
## Overview
This PR implements the strict internal domain models for `subject`, `resource`, and `permission`. It establishes explicit bounded context paths ensuring future logic operates securely on types rather than generic strings.

## Changes Included
- **`internal/{domain}/{domain}.go`**: Established domain types for `subject.ID`, `resource.ID`, and `permission.Name`.
- **`internal/authorization/service.go`**: Refactored the core service logic to intercept generic strings and enforce domain mapping before database delegation occurs. 
  - *Architectural Note:* This ensures we remain strictly type-safe internally without forcing consuming apps to import our `internal/` packages just to talk to the public Authorizer interface.

- Closes #4 