### PR TITLE
[FEAT]: Implement native net/http adapter for authorization APIs

### DIFF
--- a/internal/http/handlers.go
+++ b/internal/http/handlers.go
@@ -1,0 +1,81 @@
+package http
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/lsflk/bouncer/pkg/bouncer"
+)
+
+type Handler struct {
+	authorizer bouncer.Authorizer
+}
+
+func NewHandler(authorizer bouncer.Authorizer) *Handler {
+	return &Handler{authorizer: authorizer}
+}
+
+// PermissionRequest represents the standard JSON payload for authorization APIs.
+type PermissionRequest struct {
+	SubjectID  string `json:"subject_id"`
+	ResourceID string `json:"resource_id"`
+	Permission string `json:"permission"`
+}
+
+// HandleCheck processes requests to check if a subject has a permission.
+func (h *Handler) HandleCheck(w http.ResponseWriter, r *http.Request) {
+	var req PermissionRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid block payload", http.StatusBadRequest)
+		return
+	}
+
+	allowed, err := h.authorizer.HasPermission(r.Context(), req.SubjectID, req.ResourceID, req.Permission)
+	if err != nil {
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if allowed {
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]bool{"allowed": true})
+	} else {
+		w.WriteHeader(http.StatusForbidden)
+		json.NewEncoder(w).Encode(map[string]bool{"allowed": false})
+	}
+}
+
+// HandleGrant processes requests to grant a permission.
+func (h *Handler) HandleGrant(w http.ResponseWriter, r *http.Request) {
+	var req PermissionRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid block payload", http.StatusBadRequest)
+		return
+	}
+
+	err := h.authorizer.GrantPermission(r.Context(), req.SubjectID, req.ResourceID, req.Permission)
+	if err != nil {
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+// HandleRevoke processes requests to revoke a permission.
+func (h *Handler) HandleRevoke(w http.ResponseWriter, r *http.Request) {
+	var req PermissionRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid block payload", http.StatusBadRequest)
+		return
+	}
+
+	err := h.authorizer.RevokePermission(r.Context(), req.SubjectID, req.ResourceID, req.Permission)
+	if err != nil {
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}

--- a/pkg/httpmux/routes.go
+++ b/pkg/httpmux/routes.go
@@ -1,0 +1,28 @@
+package httpmux
+
+import (
+	"net/http"
+
+	internalhttp "github.com/lsflk/bouncer/internal/http"
+	"github.com/lsflk/bouncer/pkg/bouncer"
+)
+
+// MuxAdapter holds the internal HTTP handler configurations securely.
+type MuxAdapter struct {
+	handler internalhttp.Handler
+}
+
+// New creates a new Mux adapter statefully bound to the Bouncer Authorizer.
+func New(authorizer bouncer.Authorizer) *MuxAdapter {
+	return &MuxAdapter{
+		handler: *internalhttp.NewHandler(authorizer),
+	}
+}
+
+// RegisterRoutes safely attaches Bouncer authorization endpoints to a multiplexer.
+func (a *MuxAdapter) RegisterRoutes(mux *http.ServeMux) error {
+	mux.HandleFunc("POST /v1/permissions/check", a.handler.HandleCheck)
+	mux.HandleFunc("POST /v1/permissions/grant", a.handler.HandleGrant)
+	mux.HandleFunc("POST /v1/permissions/revoke", a.handler.HandleRevoke)
+	return nil
+}


### PR DESCRIPTION
## Overview
This PR introduces the native top-level HTTP Adapter, allowing consuming applications to optionally expose the Bouncer authorization APIs remotely over REST natively, without needing a direct database binding.

## Changes Included
- **`internal/http/handlers.go`**: Implemented internal JSON payload parsers (`subject_id`, `resource_id`, `permission`). These securely isolate the raw string mapping and JSON serialization away from the `bouncer.Authorizer` core layer.
- **`pkg/httpmux/routes.go`**: Exported the `RegisterRoutes` configuration block. It utilizes the modern Go 1.22+ `*http.ServeMux` to route `POST /v1/permissions/...` endpoints, ensuring consuming applications can plug the library directly into their native web server routers.

## Architectural Notes
- **Zero Dependencies:** Following best practices and recent Go compiler advancements (Go 1.22 method routing), this adapter utilizes standard library `net/http` exclusively. Bouncer remains 100% dependency-free.

- Closes #5 