### PR TITLE
feat: add initial PostgreSQL schema for permission grants

### DIFF
--- a/internal/storage/postgres/migrations/001_initial_schema.sql
+++ b/internal/storage/postgres/migrations/001_initial_schema.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS permission_grants (
+	subject_id TEXT NOT NULL,
+	resource_id TEXT NOT NULL,
+	permission_name TEXT NOT NULL,
+	PRIMARY KEY (subject_id, resource_id, permission_name)
+);


### PR DESCRIPTION
### **Overview**
- Adds the initial PostgreSQL schema for Bouncer authorization data.
- Stores direct permission grants in a simple, opaque table structure.
- Keeps the database layer ready for exact permission lookups and future storage work.
#
### **Changes Included**
- Created the initial migration for PostgreSQL.
- Added a permission_grants table with:
  - `subject_id`
  - `resource_id`
  - `permission_name`
- Added a composite primary key on all three columns to prevent duplicate grants.
- Kept the schema minimal with no foreign keys or hierarchy assumptions.

closes #2 