### PR TITLE
3 postgre sql adapter for the store interface

### DIFF
--- a/internal/storage/postgres/migrations/001_initial_schema.sql
+++ b/internal/storage/postgres/migrations/001_initial_schema.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS permission_grants (
+	subject_id TEXT NOT NULL,
+	resource_id TEXT NOT NULL,
+	permission_name TEXT NOT NULL,
+	PRIMARY KEY (subject_id, resource_id, permission_name)
+);

--- a/internal/storage/postgres/queries.go
+++ b/internal/storage/postgres/queries.go
@@ -1,0 +1,26 @@
+package postgres
+
+// SQL query constants for permission management.
+
+const (
+	// QueryHasPermission checks if a permission grant exists.
+	QueryHasPermission = `
+		SELECT EXISTS(
+			SELECT 1 FROM permission_grants
+			WHERE subject_id = $1 AND resource_id = $2 AND permission_name = $3
+		)
+	`
+
+	// QueryGrantPermission inserts a permission grant, ignoring duplicates.
+	QueryGrantPermission = `
+		INSERT INTO permission_grants (subject_id, resource_id, permission_name)
+		VALUES ($1, $2, $3)
+		ON CONFLICT DO NOTHING
+	`
+
+	// QueryRevokePermission removes a permission grant.
+	QueryRevokePermission = `
+		DELETE FROM permission_grants
+		WHERE subject_id = $1 AND resource_id = $2 AND permission_name = $3
+	`
+)

--- a/pkg/postgresstore/store.go
+++ b/pkg/postgresstore/store.go
@@ -1,0 +1,41 @@
+package postgresstore
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/lsflk/bouncer/internal/storage/postgres"
+)
+
+// PostgresStore implements the bouncer.Store interface using PostgreSQL.
+type PostgresStore struct {
+	db *sql.DB
+}
+
+// New creates a new PostgreSQL store backed by the provided database connection.
+func New(db *sql.DB) *PostgresStore {
+	return &PostgresStore{db: db}
+}
+
+// HasPermission checks if a subject has a permission on a resource.
+func (s *PostgresStore) HasPermission(ctx context.Context, subjectID string, resourceID string, permission string) (bool, error) {
+	var exists bool
+	err := s.db.QueryRowContext(ctx, postgres.QueryHasPermission, subjectID, resourceID, permission).Scan(&exists)
+	if err != nil {
+		return false, err
+	}
+	return exists, nil
+}
+
+// GrantPermission grants a permission to a subject on a resource.
+// If the permission already exists, it is silently ignored.
+func (s *PostgresStore) GrantPermission(ctx context.Context, subjectID string, resourceID string, permission string) error {
+	_, err := s.db.ExecContext(ctx, postgres.QueryGrantPermission, subjectID, resourceID, permission)
+	return err
+}
+
+// RevokePermission removes a permission from a subject on a resource.
+func (s *PostgresStore) RevokePermission(ctx context.Context, subjectID string, resourceID string, permission string) error {
+	_, err := s.db.ExecContext(ctx, postgres.QueryRevokePermission, subjectID, resourceID, permission)
+	return err
+}


### PR DESCRIPTION
### **Overview**
- Implements the PostgreSQL adapter to satisfy the `bouncer.Store` interface.
- Enables Bouncer to persist and evaluate permissions against PostgreSQL.
- Keeps PostgreSQL-specific SQL isolated in the internal storage layer for future database portability.

#

### **Changes**
- Created store.go with `PostgresStore` type and `New(db *sql.DB)` constructor.
- Implemented three Store methods:
  - `HasPermission`: Uses `SELECT EXISTS(...)` for permission lookups.
  - `GrantPermission`: Uses `INSERT ... ON CONFLICT DO NOTHING` for idempotent grants.
  - `RevokePermission`: Uses `DELETE` to remove permissions.
- Created queries.go with SQL query constants using PostgreSQL parameter binding (`$1, $2, $3`).
- All methods use `QueryRowContext` and `ExecContext` to preserve request context and deadlines.

closes #3 