### PR TITLE
Resource registry backend for PostgreSQL Store

### DIFF
--- a/internal/authorization/service.go
+++ b/internal/authorization/service.go
@@ -7,6 +7,8 @@ type Store interface {
 	HasPermission(ctx context.Context, subjectID string, resourceID string, permission string) (bool, error)
 	GrantPermission(ctx context.Context, subjectID string, resourceID string, permission string) error
 	RevokePermission(ctx context.Context, subjectID string, resourceID string, permission string) error
+	CreateResource(ctx context.Context, resourceID string, name string, parent *string) error
+	DeleteResource(ctx context.Context, resourceID string) error
 }
 
 // Service provides authorization capabilities by interacting with the storage layer.
@@ -32,4 +34,14 @@ func (s *Service) GrantPermission(ctx context.Context, subjectID string, resourc
 // RevokePermission revokes the requested permission on the resource from the subject.
 func (s *Service) RevokePermission(ctx context.Context, subjectID string, resourceID string, permission string) error {
 	return s.store.RevokePermission(ctx, subjectID, resourceID, permission)
+}
+
+// CreateResource creates a resource in the backing store.
+func (s *Service) CreateResource(ctx context.Context, resourceID string, name string, parent *string) error {
+	return s.store.CreateResource(ctx, resourceID, name, parent)
+}
+
+// DeleteResource deletes a resource from the backing store.
+func (s *Service) DeleteResource(ctx context.Context, resourceID string) error {
+	return s.store.DeleteResource(ctx, resourceID)
 }

--- a/internal/storage/postgres/migrations/001_initial_schema.sql
+++ b/internal/storage/postgres/migrations/001_initial_schema.sql
@@ -1,0 +1,15 @@
+CREATE TABLE IF NOT EXISTS resources (
+	id TEXT PRIMARY KEY,
+	name TEXT NOT NULL,
+	parent TEXT NULL,
+	created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+	FOREIGN KEY (parent) REFERENCES resources(id) ON DELETE SET NULL
+);
+
+CREATE TABLE IF NOT EXISTS permission_grants (
+	subject_id TEXT NOT NULL,
+	resource_id TEXT NOT NULL,
+	permission_name TEXT NOT NULL,
+	PRIMARY KEY (subject_id, resource_id, permission_name),
+	FOREIGN KEY (resource_id) REFERENCES resources(id) ON DELETE CASCADE
+);

--- a/internal/storage/postgres/queries.go
+++ b/internal/storage/postgres/queries.go
@@ -1,0 +1,38 @@
+package postgres
+
+// SQL query constants for permission and resource management.
+
+const (
+	// QueryHasPermission checks if a permission grant exists.
+	QueryHasPermission = `
+		SELECT EXISTS(
+			SELECT 1 FROM permission_grants
+			WHERE subject_id = $1 AND resource_id = $2 AND permission_name = $3
+		)
+	`
+
+	// QueryGrantPermission inserts a permission grant, ignoring duplicates.
+	QueryGrantPermission = `
+		INSERT INTO permission_grants (subject_id, resource_id, permission_name)
+		VALUES ($1, $2, $3)
+		ON CONFLICT DO NOTHING
+	`
+
+	// QueryRevokePermission removes a permission grant.
+	QueryRevokePermission = `
+		DELETE FROM permission_grants
+		WHERE subject_id = $1 AND resource_id = $2 AND permission_name = $3
+	`
+
+	// QueryCreateResource inserts a resource with an optional parent.
+	QueryCreateResource = `
+		INSERT INTO resources (id, name, parent)
+		VALUES ($1, $2, $3)
+	`
+
+	// QueryDeleteResource removes a resource by ID.
+	QueryDeleteResource = `
+		DELETE FROM resources
+		WHERE id = $1
+	`
+)

--- a/pkg/bouncer/authorizer.go
+++ b/pkg/bouncer/authorizer.go
@@ -14,4 +14,6 @@ type Store interface {
 	HasPermission(ctx context.Context, subjectID string, resourceID string, permission string) (bool, error)
 	GrantPermission(ctx context.Context, subjectID string, resourceID string, permission string) error
 	RevokePermission(ctx context.Context, subjectID string, resourceID string, permission string) error
+	CreateResource(ctx context.Context, resourceID string, name string, parent *string) error
+	DeleteResource(ctx context.Context, resourceID string) error
 }

--- a/pkg/postgresstore/store.go
+++ b/pkg/postgresstore/store.go
@@ -1,0 +1,53 @@
+package postgresstore
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/lsflk/bouncer/internal/storage/postgres"
+)
+
+// PostgresStore implements the bouncer.Store interface using PostgreSQL.
+type PostgresStore struct {
+	db *sql.DB
+}
+
+// New creates a new PostgreSQL store backed by the provided database connection.
+func New(db *sql.DB) *PostgresStore {
+	return &PostgresStore{db: db}
+}
+
+// HasPermission checks if a subject has a permission on a resource.
+func (s *PostgresStore) HasPermission(ctx context.Context, subjectID string, resourceID string, permission string) (bool, error) {
+	var exists bool
+	err := s.db.QueryRowContext(ctx, postgres.QueryHasPermission, subjectID, resourceID, permission).Scan(&exists)
+	if err != nil {
+		return false, err
+	}
+	return exists, nil
+}
+
+// GrantPermission grants a permission to a subject on a resource.
+// If the permission already exists, it is silently ignored.
+func (s *PostgresStore) GrantPermission(ctx context.Context, subjectID string, resourceID string, permission string) error {
+	_, err := s.db.ExecContext(ctx, postgres.QueryGrantPermission, subjectID, resourceID, permission)
+	return err
+}
+
+// RevokePermission removes a permission from a subject on a resource.
+func (s *PostgresStore) RevokePermission(ctx context.Context, subjectID string, resourceID string, permission string) error {
+	_, err := s.db.ExecContext(ctx, postgres.QueryRevokePermission, subjectID, resourceID, permission)
+	return err
+}
+
+// CreateResource creates a resource with an optional parent reference.
+func (s *PostgresStore) CreateResource(ctx context.Context, resourceID string, name string, parent *string) error {
+	_, err := s.db.ExecContext(ctx, postgres.QueryCreateResource, resourceID, name, parent)
+	return err
+}
+
+// DeleteResource removes a resource by ID.
+func (s *PostgresStore) DeleteResource(ctx context.Context, resourceID string) error {
+	_, err := s.db.ExecContext(ctx, postgres.QueryDeleteResource, resourceID)
+	return err
+}


### PR DESCRIPTION
### **Description**

Implements the resource registry backend by adding a self-referential `resources` table, enforcing database-level foreign key constraints, and extending the `Store` contract with resource lifecycle operations. The PostgreSQL adapter now supports creating and deleting resources, including nullable parent handling for hierarchical resources.

### **Changes included**
- Added the `resources` table with `parent` as a nullable self-referencing foreign key.
- Updated `permission_grants.resource_id` to reference `resources(id)` with `ON DELETE CASCADE`.
- Extended `pkg/bouncer.Store` and the internal service store interface with `CreateResource` and `DeleteResource`.
- Added SQL queries for resource creation and deletion.
- Implemented the new methods in `pkg/postgresstore.PostgresStore`.

### **Validation**
- `go test Desktop.` passes successfully.

closes #10