### PR TITLE
FEAT: Add Resource Management with Create and Delete Operations

### DIFF
--- a/authorizer.go
+++ b/authorizer.go
@@ -14,4 +14,6 @@ type Store interface {
 	HasPermission(ctx context.Context, subjectID string, resourceID string, permission string) (bool, error)
 	GrantPermission(ctx context.Context, subjectID string, resourceID string, permission string) error
 	RevokePermission(ctx context.Context, subjectID string, resourceID string, permission string) error
+	CreateResource(ctx context.Context, resourceID string, name string, parentID *string) error
+	DeleteResource(ctx context.Context, resourceID string) error
 }

--- a/internal/authorization/service.go
+++ b/internal/authorization/service.go
@@ -13,6 +13,8 @@ type Store interface {
 	HasPermission(ctx context.Context, subjectID string, resourceID string, permission string) (bool, error)
 	GrantPermission(ctx context.Context, subjectID string, resourceID string, permission string) error
 	RevokePermission(ctx context.Context, subjectID string, resourceID string, permission string) error
+	CreateResource(ctx context.Context, resourceID string, name string, parentID *string) error
+	DeleteResource(ctx context.Context, resourceID string) error
 }
 
 // Service provides authorization capabilities by interacting with the storage layer.

--- a/internal/storage/postgres/migrations/001_initial_schema.sql
+++ b/internal/storage/postgres/migrations/001_initial_schema.sql
@@ -1,6 +1,15 @@
+CREATE TABLE IF NOT EXISTS resources (
+	id TEXT PRIMARY KEY,
+	name TEXT NOT NULL,
+	parent TEXT NULL,
+	created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+	FOREIGN KEY (parent) REFERENCES resources(id) ON DELETE SET NULL
+);
+
 CREATE TABLE IF NOT EXISTS permission_grants (
 	subject_id TEXT NOT NULL,
 	resource_id TEXT NOT NULL,
 	permission_name TEXT NOT NULL,
-	PRIMARY KEY (subject_id, resource_id, permission_name)
+	PRIMARY KEY (subject_id, resource_id, permission_name),
+	FOREIGN KEY (resource_id) REFERENCES resources(id) ON DELETE CASCADE
 );

--- a/internal/storage/postgres/queries.go
+++ b/internal/storage/postgres/queries.go
@@ -3,6 +3,18 @@ package postgres
 // SQL query constants for permission management.
 
 const (
+	// QueryCreateResource inserts a resource with an optional parent relationship.
+	QueryCreateResource = `
+		INSERT INTO resources (id, name, parent)
+		VALUES ($1, $2, $3)
+	`
+
+	// QueryDeleteResource removes a resource by ID.
+	QueryDeleteResource = `
+		DELETE FROM resources
+		WHERE id = $1
+	`
+
 	// QueryHasPermission checks if a permission grant exists.
 	QueryHasPermission = `
 		SELECT EXISTS(

--- a/postgresstore/store.go
+++ b/postgresstore/store.go
@@ -39,3 +39,14 @@ func (s *PostgresStore) RevokePermission(ctx context.Context, subjectID string, 
 	_, err := s.db.ExecContext(ctx, postgres.QueryRevokePermission, subjectID, resourceID, permission)
 	return err
 }
+
+func (s *PostgresStore) CreateResource(ctx context.Context, resourceID string, name string, parentID *string) error {
+	_, err := s.db.ExecContext(ctx, postgres.QueryCreateResource, resourceID, name, parentID)
+	return err
+}
+
+// DeleteResource removes a resource by ID.
+func (s *PostgresStore) DeleteResource(ctx context.Context, resourceID string) error {
+	_, err := s.db.ExecContext(ctx, postgres.QueryDeleteResource, resourceID)
+	return err
+}


### PR DESCRIPTION
### **Description**

Implements the resource registry backend by adding a self-referential `resources` table, enforcing database-level foreign key constraints, and extending the `Store` contract with resource lifecycle operations. The PostgreSQL adapter now supports creating and deleting resources, including nullable parent handling for hierarchical resources.

### **Changes included**
- Added the `resources` table with `parent` as a nullable self-referencing foreign key.
- Updated `permission_grants.resource_id` to reference `resources(id)` with `ON DELETE CASCADE`.
- Extended `pkg/bouncer.Store` and the internal service store interface with `CreateResource` and `DeleteResource`.
- Added SQL queries for resource creation and deletion.
- Implemented the new methods in `pkg/postgresstore.PostgresStore`.

### **Validation**
- `go test ./` passes successfully.

closes #10