### PR TITLE
[FEAT]: Expose Resource Management API

### DIFF
--- a/authorizer.go
+++ b/authorizer.go
@@ -7,6 +7,8 @@ type Authorizer interface {
 	HasPermission(ctx context.Context, subjectID string, resourceID string, permission string) (bool, error)
 	GrantPermission(ctx context.Context, subjectID string, resourceID string, permission string) error
 	RevokePermission(ctx context.Context, subjectID string, resourceID string, permission string) error
+	CreateResource(ctx context.Context, resourceID string, name string, parentID *string) error
+	DeleteResource(ctx context.Context, resourceID string) error
 }
 
 // Store represents the persistence layer required by the Authorizer.

--- a/httpmux/routes.go
+++ b/httpmux/routes.go
@@ -24,5 +24,7 @@ func (a *MuxAdapter) RegisterRoutes(mux *http.ServeMux) error {
 	mux.HandleFunc("POST /v1/permissions/check", a.handler.HandleCheck)
 	mux.HandleFunc("POST /v1/permissions/grant", a.handler.HandleGrant)
 	mux.HandleFunc("POST /v1/permissions/revoke", a.handler.HandleRevoke)
+	mux.HandleFunc("POST /v1/resources", a.handler.HandleCreateResource)
+	mux.HandleFunc("DELETE /v1/resources", a.handler.HandleDeleteResource)
 	return nil
 }

--- a/internal/authorization/service.go
+++ b/internal/authorization/service.go
@@ -53,3 +53,23 @@ func (s *Service) RevokePermission(ctx context.Context, subjectStr string, resou
 
 	return s.store.RevokePermission(ctx, string(subID), string(resID), string(permName))
 }
+
+// CreateResource registers a new resource in the system.
+func (s *Service) CreateResource(ctx context.Context, resourceID string, name string, parentID *string) error {
+	resID := resource.ID(resourceID)
+
+	var parent *string
+	if parentID != nil {
+		pID := resource.ID(*parentID)
+		pStr := string(pID)
+		parent = &pStr
+	}
+
+	return s.store.CreateResource(ctx, string(resID), name, parent)
+}
+
+// DeleteResource removes a resource and its associated permissions.
+func (s *Service) DeleteResource(ctx context.Context, resourceID string) error {
+	resID := resource.ID(resourceID)
+	return s.store.DeleteResource(ctx, string(resID))
+}

--- a/internal/http/handlers.go
+++ b/internal/http/handlers.go
@@ -22,6 +22,13 @@ type PermissionRequest struct {
 	Permission string `json:"permission"`
 }
 
+// ResourceRequest represents the JSON payload for resource management APIs.
+type ResourceRequest struct {
+	ResourceID string  `json:"resource_id"`
+	Name       string  `json:"name"`
+	ParentID   *string `json:"parent_id,omitempty"`
+}
+
 // HandleCheck processes requests to check if a subject has a permission.
 func (h *Handler) HandleCheck(w http.ResponseWriter, r *http.Request) {
 	var req PermissionRequest
@@ -79,3 +86,47 @@ func (h *Handler) HandleRevoke(w http.ResponseWriter, r *http.Request) {
 
 	w.WriteHeader(http.StatusOK)
 }
+
+
+// HandleCreateResource processes requests to register a new resource.
+func (h *Handler) HandleCreateResource(w http.ResponseWriter, r *http.Request) {
+	var req ResourceRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request payload", http.StatusBadRequest)
+		return
+	}
+
+	err := h.authorizer.CreateResource(r.Context(), req.ResourceID, req.Name, req.ParentID)
+	if err != nil {
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusCreated)
+}
+
+// HandleDeleteResource processes requests to remove a resource.
+func (h *Handler) HandleDeleteResource(w http.ResponseWriter, r *http.Request) {
+	resourceID := r.URL.Query().Get("resource_id")
+	if resourceID == "" {
+		// Fallback to body if query param is missing
+		var req ResourceRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err == nil {
+			resourceID = req.ResourceID
+		}
+	}
+
+	if resourceID == "" {
+		http.Error(w, "Missing resource_id", http.StatusBadRequest)
+		return
+	}
+
+	err := h.authorizer.DeleteResource(r.Context(), resourceID)
+	if err != nil {
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+


### PR DESCRIPTION
#### Summary
This PR officially exposes the resource registration and deletion capabilities through the core Bouncer library and its HTTP adapter. Previously, these methods were only available in the storage layer; they are now accessible via the main `Authorizer` interface and through new REST endpoints.

#### Changes
- **Core API**: Added `CreateResource` and `DeleteResource` to the `Authorizer` interface in `authorizer.go`.
- **Internal Service**: Implemented the new methods in `internal/authorization/service.go` with domain type mapping for `resource.ID`.
- **HTTP Adapter**:
    - Implemented `HandleCreateResource` and `HandleDeleteResource` in `internal/http/handlers.go`.
    - Registered `POST /v1/resources` and `DELETE /v1/resources` in `httpmux/routes.go`.
- **Models**: Added `ResourceRequest` JSON struct for resource-related API payloads.

#### API Specification
- **Create Resource**
    - `POST /v1/resources`
    - Payload: `{"resource_id": "res_1", "name": "Project A", "parent_id": "org_1"}`
- **Delete Resource**
    - `DELETE /v1/resources?resource_id=res_1` (or via JSON body)


- Closes #11 